### PR TITLE
Code Listener's settings can be now controled from user's environment.

### DIFF
--- a/cl/.gitignore
+++ b/cl/.gitignore
@@ -1,1 +1,2 @@
 version_cl.h
+config_cl.h

--- a/cl/cl_pp.cc
+++ b/cl/cl_pp.cc
@@ -122,7 +122,9 @@ ClPrettyPrint::ClPrettyPrint(const char *fileName, bool showTypes):
     printingArgDecls_(false)
 {
     if (&out_ == &std::cout) {
+#if CL_DEBUG_COLORED_OUTPUT
         ColorConsole::enableForTerm(STDOUT_FILENO);
+#endif
         return;
     }
 

--- a/cl/config_cl.h.default
+++ b/cl/config_cl.h.default
@@ -35,6 +35,11 @@
 #endif
 
 /**
+ * If set to '1', uses colored terminal output for ClPrettyPrint() [cl_pp.cc].
+ */
+#define CL_DEBUG_COLORED_OUTPUT         0
+
+/**
  * if 1, check each code_listener filter by the integrity checker
  */
 #define CL_DEBUG_CLF                    0

--- a/run-llvm-tests.sh
+++ b/run-llvm-tests.sh
@@ -3,6 +3,24 @@ export SELF="$0"
 export LC_ALL=C
 MAKE="make -j5"
 
+# Config file used by the CL:
+# NOTE: Make sure the "$CL_CONFIG_FILE.default" exists!
+CL_CONFIG_FILE="./cl/config_cl.h"
+
+# Current supported settings of CL:
+CL_SETTINGS=(CL_DEBUG_COLORED_OUTPUT
+             CL_DEBUG_CLF
+             CL_DEBUG_GCC_GIMPLE
+             CL_DEBUG_GCC_TREE
+             CL_DEBUG_LOCATION
+             CL_DEBUG_LOOP_SCAN
+             CL_DEBUG_POINTS_TO
+             CL_DEBUG_VAR_KILLER
+             CL_EASY_TIMER
+             CL_MSG_SQUEEZE_REPEATS
+             CLPLUG_SILENT
+             DEBUG_CL_FACTORY)
+
 die() {
     printf "%s: %s\n" "$SELF" "$*" >&2
     exit 1
@@ -30,10 +48,69 @@ EOF
     exit 1
 }
 
+# Tests if the option is set and updates the value if necessary:
+option_set() {
+  if [[ -z $1 ]]; then
+    return 1;             # Not set.
+  fi
+
+  # Obtaining the value of the option:
+  eval "OPTION_VALUE=\$$1"
+  OPTION_VALUE="$(echo $OPTION_VALUE | tr [:upper:] [:lower:])"
+
+  case $OPTION_VALUE in
+    "on" | "true")
+      OPTION_VALUE=1
+      return 0;;
+
+    "off" | "false")
+      OPTION_VALUE=0
+      return 0;;
+
+    # NOTE - maximum debug value currently supported is: 4
+    "0" | "1" | "2" | "3" | "4" )
+      return 0;;
+    
+    *)
+      return 1;;          # Something unknown ->> ignoring.
+  esac
+}
+
+# Prepares the CL in correspondence with user's environment settings:
+prepare_CL_environment() {
+  # Restores the default environment first:
+  if [[ -f "$CL_CONFIG_FILE.default" ]]; then
+    cp "$CL_CONFIG_FILE.default" "$CL_CONFIG_FILE"
+  else
+    return
+  fi
+
+  # Sets the new environment. If the user's environment is clear, than it does
+  # nothing...
+  # NOTE: Do not break the sed line below, the regular expression can be highly
+  #       error prone, thanks!
+  for option in "${CL_SETTINGS[@]}"; do
+    if option_set $option; then
+      sed -r -i -e 's/(#define[[:space:]]+)('$option')([[:space:]]+)([[:digit:]])/\1\2\3'$OPTION_VALUE'/g' "$CL_CONFIG_FILE"
+    fi
+  done
+
+  return 
+}
+
 status_update() {
     printf "\n%s...\n\n" "$*"
     tty >/dev/null && printf "\033]0;%s\a" "$*"
 }
+
+# Prepare the CL environment for the compilation:
+prepare_CL_environment
+
+# Turn the NDEBUG off if requested:
+# NOTE: '$' is intentionally missing before 'CL_DEBUG'
+if option_set CL_DEBUG && test $OPTION_VALUE -eq 1; then
+  CL_DEBUG_STRING="-D CL_DEBUG=ON";
+fi
 
 if [ "$#" == 3 ]; then
 
@@ -57,7 +134,7 @@ if [ "$#" == 3 ]; then
         || die "OPT_HOST is not an absolute path to an executable file: $OPT_HOST"
 
     status_update "Checking whether $1 works"
-    $MAKE -C $1 check CMAKE="cmake -D CLANG_HOST='$HOST' -D OPT_HOST='$OPT_HOST' -D ENABLE_LLVM=ON -D GCC_EXEC_PREFIX='timeout 5'"
+    $MAKE -C $1 check CMAKE="cmake -D CLANG_HOST='$HOST' -D OPT_HOST='$OPT_HOST' -D ENABLE_LLVM=ON -D GCC_EXEC_PREFIX='timeout 5' $CL_DEBUG_STRING"
 
 else
     test 1 = "$#" || usage
@@ -65,5 +142,5 @@ else
     test cl = "$1" || test sl = "$1" || test fa = "$1" || usage
 
     status_update "Checking whether $1 works"
-    $MAKE -C $1 check CMAKE="cmake -D ENABLE_LLVM=ON -D GCC_EXEC_PREFIX='timeout 5'" 
+    $MAKE -C $1 check CMAKE="cmake -D ENABLE_LLVM=ON -D GCC_EXEC_PREFIX='timeout 5' $CL_DEBUG_STRING" 
 fi

--- a/switch-host-gcc.sh
+++ b/switch-host-gcc.sh
@@ -26,6 +26,32 @@ die() {
     exit 1
 }
 
+usage() {
+    printf "Usage: %s GCC_HOST\n" "$SELF" >&2
+    cat >&2 << EOF
+
+    Use this script to (re)build Predator and/or Forester against an arbitrary
+    build of host GCC.  The host GCC needs to be built with the support for GCC
+    plug-ins.  The recommended version of host GCC is 4.9.0 but Predator can be
+    loaded also into older versions of GCC (plug-ins are supported since 4.5.0).
+    For host GCC 4.6.x and older, please use the compatibility patches in the
+    build-aux directory.
+
+    GCC_HOST is a gcc(1) executable file that is built with the support for
+    GCC plug-ins.  The most common location of the system GCC is /usr/bin/gcc.
+    If you have multiple versions of gcc installed on the system, it can be
+    something like /usr/bin/gcc-4.9.0.  You can also provide a local build of
+    GCC, e.g.  /home/bob/gcc-4.9.0/bin/gcc.  Please avoid setting GCC_HOST to
+    a ccache, distcc, or another GCC wrapper.  Such setups are not supported
+    yet.
+
+    On some Linux distributions you need to install an optional package (e.g.
+    gcc-plugin-devel on Fedora) in order to be able to build GCC plug-ins.
+
+EOF
+    exit 1
+}
+
 # Tests if the option is set and updates the value if necessary:
 option_set() {
   if [[ -z $1 ]]; then
@@ -76,32 +102,6 @@ prepare_CL_environment() {
   return 
 }
 
-usage() {
-    printf "Usage: %s GCC_HOST\n" "$SELF" >&2
-    cat >&2 << EOF
-
-    Use this script to (re)build Predator and/or Forester against an arbitrary
-    build of host GCC.  The host GCC needs to be built with the support for GCC
-    plug-ins.  The recommended version of host GCC is 4.9.0 but Predator can be
-    loaded also into older versions of GCC (plug-ins are supported since 4.5.0).
-    For host GCC 4.6.x and older, please use the compatibility patches in the
-    build-aux directory.
-
-    GCC_HOST is a gcc(1) executable file that is built with the support for
-    GCC plug-ins.  The most common location of the system GCC is /usr/bin/gcc.
-    If you have multiple versions of gcc installed on the system, it can be
-    something like /usr/bin/gcc-4.9.0.  You can also provide a local build of
-    GCC, e.g.  /home/bob/gcc-4.9.0/bin/gcc.  Please avoid setting GCC_HOST to
-    a ccache, distcc, or another GCC wrapper.  Such setups are not supported
-    yet.
-
-    On some Linux distributions you need to install an optional package (e.g.
-    gcc-plugin-devel on Fedora) in order to be able to build GCC plug-ins.
-
-EOF
-    exit 1
-}
-
 test 1 = "$#" || usage
 
 status_update() {
@@ -129,7 +129,7 @@ status_update "Nuking working directory"
 $MAKE distclean \
     || die "'$MAKE distclean' has failed"
 
-# Prepare the environment for the compilation:
+# Prepare the CL environment for the compilation:
 prepare_CL_environment
 
 # Turn the NDEBUG off if requested:

--- a/switch-host-gcc.sh
+++ b/switch-host-gcc.sh
@@ -3,9 +3,77 @@ export SELF="$0"
 export LC_ALL=C
 MAKE="make -j5"
 
+# Config file used by the CL:
+# NOTE: Make sure the "$CL_CONFIG_FILE.default" exists!
+CL_CONFIG_FILE="./cl/config_cl.h"
+
+# Current supported settings of CL:
+CL_SETTINGS=(CL_DEBUG_COLORED_OUTPUT
+             CL_DEBUG_CLF
+             CL_DEBUG_GCC_GIMPLE
+             CL_DEBUG_GCC_TREE
+             CL_DEBUG_LOCATION
+             CL_DEBUG_LOOP_SCAN
+             CL_DEBUG_POINTS_TO
+             CL_DEBUG_VAR_KILLER
+             CL_EASY_TIMER
+             CL_MSG_SQUEEZE_REPEATS
+             CLPLUG_SILENT
+             DEBUG_CL_FACTORY)
+
 die() {
     printf "%s: %s\n" "$SELF" "$*" >&2
     exit 1
+}
+
+# Tests if the option is set and updates the value if necessary:
+option_set() {
+  if [[ -z $1 ]]; then
+    return 1;             # Not set.
+  fi
+
+  # Obtaining the value of the option:
+  eval "OPTION_VALUE=\$$1"
+  OPTION_VALUE="$(echo $OPTION_VALUE | tr [:upper:] [:lower:])"
+
+  case $OPTION_VALUE in
+    "on" | "true")
+      OPTION_VALUE=1
+      return 0;;
+
+    "off" | "false")
+      OPTION_VALUE=0
+      return 0;;
+
+    # NOTE - maximum debug value currently supported is: 4
+    "0" | "1" | "2" | "3" | "4" )
+      return 0;;
+    
+    *)
+      return 1;;          # Something unknown ->> ignoring.
+  esac
+}
+
+# Prepares the CL in correspondence with user's environment settings:
+prepare_CL_environment() {
+  # Restores the default environment first:
+  if [[ -f "$CL_CONFIG_FILE.default" ]]; then
+    cp "$CL_CONFIG_FILE.default" "$CL_CONFIG_FILE"
+  else
+    return
+  fi
+
+  # Sets the new environment. If the user's environment is clear, than it does
+  # nothing...
+  # NOTE: Do not break the sed line below, the regular expression can be highly
+  #       error prone, thanks!
+  for option in "${CL_SETTINGS[@]}"; do
+    if option_set $option; then
+      sed -r -i -e 's/(#define[[:space:]]+)('$option')([[:space:]]+)([[:digit:]])/\1\2\3'$OPTION_VALUE'/g' "$CL_CONFIG_FILE"
+    fi
+  done
+
+  return 
 }
 
 usage() {
@@ -61,8 +129,17 @@ status_update "Nuking working directory"
 $MAKE distclean \
     || die "'$MAKE distclean' has failed"
 
+# Prepare the environment for the compilation:
+prepare_CL_environment
+
+# Turn the NDEBUG off if requested:
+# NOTE: '$' is intentionally missing before 'CL_DEBUG'
+if option_set CL_DEBUG && test $OPTION_VALUE -eq 1; then
+  CL_DEBUG_STRING="-D CL_DEBUG=ON";
+fi
+
 status_update "Trying to build Code Listener"
-$MAKE -C cl CMAKE="cmake -D GCC_HOST='$GCC_HOST'" \
+$MAKE -C cl CMAKE="cmake -D GCC_HOST='$GCC_HOST' $CL_DEBUG_STRING" \
     || die "failed to build Code Listener"
 
 status_update "Checking whether Code Listener works"


### PR DESCRIPTION
Users can now put the `export CODE_LISTENER_OPTION=VALUE` in their .bashrc file to permamently change the values of Code Listener they require, without affecting the git's tracking system.

Supported values  (case-insensitive): `ON/OFF, TRUE/FALSE, 0/1/2/3/4`

**Example:**

``` bash
export CL_DEBUG_GCC_TREE='true'
```

This is mostly useful for developers -- my suggestion is adding the same functionality for other parts of project also (predator, forester, fwnull & vra -- if they contain such option settings).

The `CL_DEBUG` was also introduced -- e.g. `export CL_DEBUG='ON'` can be used -- to compile the CL with the `NDEBUG` turned OFF.

**Environment default settings:**
If the user doesn't have any exported CL settings values, the updated [switch-host-gcc.sh](https://github.com/deekej/predator/blob/upstream/CL-env-settings/switch-host-gcc.sh), [switch-host-clang.sh](https://github.com/deekej/predator/blob/upstream/CL-env-settings/switch-host-clang.sh) and [run-llvm-tests.sh](https://github.com/deekej/predator/blob/upstream/CL-env-settings/run-llvm-tests.sh) scripts behave same as before. Setting the environment and switching it back also results in the default behaviour (before the update).

**Consequences:**
Because of it, the `cl/config_cl.h` has been moved as `cl/config_cl.h.default`. The `cl/config_cl.h` still has the same functionality and is used for inclusion in other files when compiling CL, but it is being modified depending on the users settings. It is therefore not tracked by git anymore, it is always copied from default file and updated depending on user's environment settings.

Initial build through

**Other changes:**
The colored output for `ClPrettyPrint()` can be now configured from Code Listener's config also and it has been turned OFF by default.

**Supported environment settings:**
- CL_DEBUG_COLORED_OUTPUT
- CL_DEBUG_CLF
- CL_DEBUG_GCC_GIMPLE
- CL_DEBUG_GCC_TREE
- CL_DEBUG_LOCATION
- CL_DEBUG_LOOP_SCAN
- CL_DEBUG_POINTS_TO
- CL_DEBUG_VAR_KILLER
- CL_EASY_TIMER
- CL_MSG_SQUEEZE_REPEATS
- CLPLUG_SILENT
- DEBUG_CL_FACTORY

Best regards,

Dee'Kej
