### PR TITLE
sl/symproc: model allocation of zero size properly

### DIFF
--- a/sl/symheap.cc
+++ b/sl/symheap.cc
@@ -2033,6 +2033,10 @@ TFldId SymHeapCore::Private::writeUniformBlock(
         const UniformBlock         &ub,
         TValSet                    *killedPtrs)
 {
+    if (!ub.size)
+        // writing block of zero size is a no-op
+        return FLD_INVALID;
+
     // acquire field ID
     BlockEntity *blData =
         new BlockEntity(BK_UNIFORM, obj, ub.off, ub.size, ub.tplValue);

--- a/sl/symproc.cc
+++ b/sl/symproc.cc
@@ -1501,18 +1501,7 @@ void SymExecCore::execHeapAlloc(
         // error alredy emitted
         return;
 
-    if (!size.hi) {
-        CL_WARN_MSG(lw_, "POSIX says that, given zero size, the behavior of \
-malloc/calloc is implementation-defined");
-        CL_NOTE_MSG(lw_, "assuming NULL as the result");
-        this->printBackTrace(ML_WARN);
-        this->setValueOf(lhs, VAL_NULL);
-        this->killInsn(insn);
-        dst.insert(sh_);
-        return;
-    }
-
-    if (ep_.oomSimulation) {
+    if (ep_.oomSimulation || /* malloc(0) may return NULL */ !size.hi) {
         // clone the heap and core
         SymHeap oomHeap(sh_);
         SymExecCore oomCore(oomHeap, bt_, ep_);

--- a/tests/predator-regre/test-0239.err
+++ b/tests/predator-regre/test-0239.err
@@ -1,38 +1,23 @@
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:18: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:19: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:20: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:12: error: dereferencing object of size 4B out of bounds
+test-0239.c:12: note: the pointer being dereferenced points 0B beyond a variable on stack of size 12B
 test-0239.c:24: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:12: error: dereferencing object of size 4B out of bounds

--- a/tests/predator-regre/test-0239.err.exit_leaks
+++ b/tests/predator-regre/test-0239.err.exit_leaks
@@ -1,38 +1,23 @@
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:18: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:19: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:20: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:12: error: dereferencing object of size 4B out of bounds
+test-0239.c:12: note: the pointer being dereferenced points 0B beyond a variable on stack of size 12B
 test-0239.c:24: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:12: error: dereferencing object of size 4B out of bounds

--- a/tests/predator-regre/test-0239.err.oom
+++ b/tests/predator-regre/test-0239.err.oom
@@ -1,17 +1,7 @@
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:18: note: from call of foo()
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
+test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:19: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:20: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
@@ -20,8 +10,13 @@ test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
+test-0239.c:22: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
+test-0239.c:22: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
@@ -33,8 +28,7 @@ test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
@@ -46,8 +40,29 @@ test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
+test-0239.c:23: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
+test-0239.c:23: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
+test-0239.c:23: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:12: error: dereferencing object of size 4B out of bounds
+test-0239.c:12: note: the pointer being dereferenced points 0B beyond a variable on stack of size 12B
+test-0239.c:24: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:12: error: dereferencing object of size 4B out of bounds
+test-0239.c:12: note: the pointer being dereferenced points 0B beyond a variable on stack of size 12B
+test-0239.c:24: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:12: error: dereferencing object of size 4B out of bounds
+test-0239.c:12: note: the pointer being dereferenced points 0B beyond a variable on stack of size 12B
+test-0239.c:24: note: from call of foo()
+test-0239.c:15: note: from call of main()
+test-0239.c:12: error: dereferencing object of size 4B out of bounds
+test-0239.c:12: note: the pointer being dereferenced points 0B beyond a variable on stack of size 12B
 test-0239.c:24: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:12: error: dereferencing object of size 4B out of bounds

--- a/tests/predator-regre/test-0239.err.uninit
+++ b/tests/predator-regre/test-0239.err.uninit
@@ -1,38 +1,23 @@
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:18: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:19: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
-test-0239.c:20: note: from call of foo()
-test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:21: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:22: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:11: warning: memory leak detected while destroying a variable on stack
 test-0239.c:23: note: from call of foo()
 test-0239.c:15: note: from call of main()
-test-0239.c:9: warning: POSIX says that, given zero size, the behavior of malloc/calloc is implementation-defined
-test-0239.c:9: note: assuming NULL as the result
+test-0239.c:12: error: dereferencing object of size 4B out of bounds
+test-0239.c:12: note: the pointer being dereferenced points 0B beyond a variable on stack of size 12B
 test-0239.c:24: note: from call of foo()
 test-0239.c:15: note: from call of main()
 test-0239.c:12: error: dereferencing object of size 4B out of bounds


### PR DESCRIPTION
POSIX says that malloc(0) returns either NULL, or a non-NULL pointer
that can be passed as an argument to free().  Instead of printing a
warning, model both the cases.