### PR TITLE
cmake: use -std=c++14 with ENABLE_LLVM, -std=c++11 otherwise

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ matrix:
               - CXX=/usr/bin/clang++-6.0
           script:
               - git clone --depth 1 https://github.com/VeriFIT/ProStatA.git passes-src
-              - sed -e 's|^ *if(.*VERSION_GREATER_EQUAL.*)$|if(FALSE)|' -i build-aux/common.cmake passes-src/passes/CMakeLists.txt
+              - sed -e 's|^ *if(.*VERSION_GREATER_EQUAL.*)$|if(FALSE)|' -i passes-src/passes/CMakeLists.txt
               - ./switch-host-llvm.sh /usr/lib/llvm-6.0/cmake
 
 

--- a/build-aux/common.cmake
+++ b/build-aux/common.cmake
@@ -82,16 +82,12 @@ include_directories(SYSTEM ../include)
 ADD_C_FLAG(       "fPIC"                 "-fPIC")
 ADD_C_FLAG(       "hidden_visibility"    "-fvisibility=hidden")
 
-# we use c99 to compile *.c and c++0x to compile *.cc
+# we use c99 to compile *.c and c++11/c++14 to compile *.cc
 ADD_C_ONLY_FLAG(  "STD_C99"              "-std=c99")
 if(ENABLE_LLVM)
-    if(${LLVM_VERSION_MAJOR} VERSION_GREATER_EQUAL "10.0")
-        ADD_CXX_ONLY_FLAG("STD_CXX_14"       "-std=c++14")
-    else()
-        ADD_CXX_ONLY_FLAG("STD_CXX_11"       "-std=c++11")
-    endif()
+    ADD_CXX_ONLY_FLAG("STD_CXX_14"       "-std=c++14")
 else()
-    ADD_CXX_ONLY_FLAG("STD_CXX_0X"       "-std=c++0x")
+    ADD_CXX_ONLY_FLAG("STD_CXX_11"       "-std=c++11")
 endif()
 
 # tweak warnings


### PR DESCRIPTION
`g++ -std=c++11` and `clang++ -std=c++14` now work on all distros we care about, whereas the `VERSION_GREATER_EQUAL` cmake macro is not available in older versions of cmake.