### PR TITLE
sl/symproc: model realloc(ptr, 0) properly

### DIFF
--- a/build-aux/llvm.patch
+++ b/build-aux/llvm.patch
@@ -2039,7 +2039,7 @@ index f796e55e..134d28c3 100644
 @@ -1,5 +1,7 @@
  test-0256.c:10: error: invalid realloc()
 -test-0256.c:38: error: dereference of already deleted heap object
- test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+ test-0256.c:46: warning: memory leak detected while destroying a variable on stack
  test-0256.c:42: error: dereferencing object of size 4B out of bounds
  test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B
 +test-0256.c:38: error: dereference of already deleted heap object
@@ -2052,7 +2052,7 @@ index f796e55e..134d28c3 100644
 @@ -1,5 +1,7 @@
  test-0256.c:10: error: invalid realloc()
 -test-0256.c:38: error: dereference of already deleted heap object
- test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+ test-0256.c:46: warning: memory leak detected while destroying a variable on stack
  test-0256.c:42: error: dereferencing object of size 4B out of bounds
  test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B
 +test-0256.c:38: error: dereference of already deleted heap object
@@ -2062,27 +2062,30 @@ diff --git a/tests/predator-regre/test-0256.err.oom b/tests/predator-regre/test-
 index db74a923..f13255fb 100644
 --- a/tests/predator-regre/test-0256.err.oom
 +++ b/tests/predator-regre/test-0256.err.oom
-@@ -1,7 +1,9 @@
+@@ -1,9 +1,11 @@
  test-0256.c:10: error: invalid realloc()
 -test-0256.c:22: warning: memory leak detected while destroying a variable on stack
 -test-0256.c:38: error: dereference of already deleted heap object
 +test-0256.c:23: warning: memory leak detected while destroying a variable on stack
- test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+ test-0256.c:46: warning: memory leak detected while assigning a variable on stack
+ test-0256.c:46: warning: memory leak detected while destroying a variable on stack
  test-0256.c:42: error: dereferencing object of size 4B out of bounds
  test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B
 +test-0256.c:38: error: dereference of already deleted heap object
 +test-0256.c:42: error: dereferencing object of size 4B out of bounds
 +test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B
- test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+ test-0256.c:46: warning: memory leak detected while assigning a variable on stack
+ test-0256.c:46: warning: memory leak detected while destroying a variable on stack
 diff --git a/tests/predator-regre/test-0256.err.uninit b/tests/predator-regre/test-0256.err.uninit
 index 6c047e7e..5cbc8a92 100644
 --- a/tests/predator-regre/test-0256.err.uninit
 +++ b/tests/predator-regre/test-0256.err.uninit
-@@ -1,6 +1,8 @@
- test-0256.c:10: error: invalid realloc()
+@@ -2,7 +2,9 @@
  test-0256.c:10: note: the value being reallocated is an untouched contents of stack
+ test-0256.c:10: error: invalid realloc()
+ test-0256.c:10: note: the value being freed is an untouched contents of stack
 -test-0256.c:38: error: dereference of already deleted heap object
- test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+ test-0256.c:46: warning: memory leak detected while destroying a variable on stack
  test-0256.c:42: error: dereferencing object of size 4B out of bounds
  test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B
 +test-0256.c:38: error: dereference of already deleted heap object

--- a/tests/predator-regre/README
+++ b/tests/predator-regre/README
@@ -809,6 +809,8 @@ Tests taken from Forester
     test-0265.c - a test for bitfields
                 - taken from https://sv-comp.sosy-lab.org/2020/results/sv-benchmarks/c/ldv-memsafety-bitfields/test-bitfields-3.1-1.c
 
+    test-0266.c - a regression test for simulation of realloc(ptr, 0)
+
 Data reinterpretation
 =====================
 

--- a/tests/predator-regre/test-0256.err
+++ b/tests/predator-regre/test-0256.err
@@ -1,5 +1,5 @@
 test-0256.c:10: error: invalid realloc()
 test-0256.c:38: error: dereference of already deleted heap object
-test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+test-0256.c:46: warning: memory leak detected while destroying a variable on stack
 test-0256.c:42: error: dereferencing object of size 4B out of bounds
 test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B

--- a/tests/predator-regre/test-0256.err.exit_leaks
+++ b/tests/predator-regre/test-0256.err.exit_leaks
@@ -1,5 +1,5 @@
 test-0256.c:10: error: invalid realloc()
 test-0256.c:38: error: dereference of already deleted heap object
-test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+test-0256.c:46: warning: memory leak detected while destroying a variable on stack
 test-0256.c:42: error: dereferencing object of size 4B out of bounds
 test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B

--- a/tests/predator-regre/test-0256.err.oom
+++ b/tests/predator-regre/test-0256.err.oom
@@ -1,7 +1,9 @@
 test-0256.c:10: error: invalid realloc()
 test-0256.c:22: warning: memory leak detected while destroying a variable on stack
 test-0256.c:38: error: dereference of already deleted heap object
-test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+test-0256.c:46: warning: memory leak detected while assigning a variable on stack
+test-0256.c:46: warning: memory leak detected while destroying a variable on stack
 test-0256.c:42: error: dereferencing object of size 4B out of bounds
 test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B
-test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+test-0256.c:46: warning: memory leak detected while assigning a variable on stack
+test-0256.c:46: warning: memory leak detected while destroying a variable on stack

--- a/tests/predator-regre/test-0256.err.uninit
+++ b/tests/predator-regre/test-0256.err.uninit
@@ -1,6 +1,8 @@
 test-0256.c:10: error: invalid realloc()
 test-0256.c:10: note: the value being reallocated is an untouched contents of stack
+test-0256.c:10: error: invalid realloc()
+test-0256.c:10: note: the value being freed is an untouched contents of stack
 test-0256.c:38: error: dereference of already deleted heap object
-test-0256.c:46: warning: POSIX says that, given zero size, the behavior of realloc is implementation-defined
+test-0256.c:46: warning: memory leak detected while destroying a variable on stack
 test-0256.c:42: error: dereferencing object of size 4B out of bounds
 test-0256.c:42: note: the pointer being dereferenced points 0B beyond a heap object of size 8B

--- a/tests/predator-regre/test-0266.c
+++ b/tests/predator-regre/test-0266.c
@@ -1,0 +1,24 @@
+#include <stdlib.h>
+
+int main()
+{
+    void *ptr = malloc(1U);
+    if (!ptr)
+        return EXIT_FAILURE;
+
+    void *tmp = realloc(ptr, 0);
+    if (tmp)
+        free(tmp);
+
+    free(tmp);
+}
+
+/**
+ * @file test-0266.c
+ *
+ * @brief a regression test for simulation of realloc(ptr, 0)
+ *
+ * @attention
+ * This description is automatically imported from tests/predator-regre/README.
+ * Any changes made to this comment will be thrown away on the next import.
+ */

--- a/tests/predator-regre/test-0266.err
+++ b/tests/predator-regre/test-0266.err
@@ -1,0 +1,1 @@
+test-0266.c:13: error: double free by free()

--- a/tests/predator-regre/test-0266.err.exit_leaks
+++ b/tests/predator-regre/test-0266.err.exit_leaks
@@ -1,0 +1,1 @@
+test-0266.c:13: error: double free by free()

--- a/tests/predator-regre/test-0266.err.oom
+++ b/tests/predator-regre/test-0266.err.oom
@@ -1,0 +1,2 @@
+test-0266.c:9: warning: memory leak detected while destroying a variable on stack
+test-0266.c:13: error: double free by free()

--- a/tests/predator-regre/test-0266.err.uninit
+++ b/tests/predator-regre/test-0266.err.uninit
@@ -1,0 +1,1 @@
+test-0266.c:13: error: double free by free()


### PR DESCRIPTION
POSIX says that `realloc(ptr, 0)` returns either NULL, or a non-NULL pointer that can be passed as an argument to `free()`.  Instead of printing a warning, model both the cases.  This is a follow-up to the corresponding fix for `malloc(0)`.

Use `git show -w sl` to see the actual code changes in this commit.