### PR TITLE
sl: fix clobber for local variables allocated by __builtin_alloca

### DIFF
--- a/sl/symproc.cc
+++ b/sl/symproc.cc
@@ -2855,7 +2855,9 @@ void SymExecCore::handleClobber(const CodeStorage::Insn &insn)
     CL_BREAK_IF(!isOnStack(sh_.objStorClass(obj)));
 
     // needed only for more precise diagnostic messages
-    const CVar cv = sh_.cVarByObject(obj);
+    const cl_uid_t uid = varIdFromOperand(&op);
+    const int nestLevel = bt_->countOccurrencesOfTopFnc();
+    const CVar cv(uid, nestLevel);
     if (-1 != cv.uid) {
         const struct cl_loc *varLoc;
         const std::string varString = varToString(sh_.stor(), cv.uid, &varLoc);


### PR DESCRIPTION
I mixed 2 things in one commit in the previous PR.