### PR TITLE
sl/check-property.sh: ignore unreachable label

### DIFF
--- a/sl/check-property.sh.in
+++ b/sl/check-property.sh.in
@@ -5,6 +5,8 @@ export CCACHE_DISABLE=1
 
 export MSG_INFLOOP=': warning: end of function .*\(\) has not been reached'
 export MSG_LABEL_FOUND=': error: error label "ERROR" has been reached'
+export MSG_LABEL_UNREACHABLE=': warning: unreachable label .*'
+export MSG_WARNINGS_REPORTED=': warning: Pass has reported some warnings'
 export MSG_VERIFIER_ERROR_FOUND=': (error|warning): __VERIFIER_error\(\) reached'
 export MSG_OUR_WARNINGS=': warning: .*(\[-fplugin=libsl.so\]|\[-sl\])$'
 export MSG_TIME_ELAPSED=': note: clEasyRun\(\) took '
@@ -277,7 +279,11 @@ parse_output() {
             fail "$line"
 
         elif match "$line" "$MSG_INFLOOP"; then
+             match "$line" "$MSG_WARNINGS_REPORTED" || \
+             match "$line" "$MSG_LABEL_UNREACHABLE" || \
             # infinite loop does not mean FALSE, ignore them
+            # reported warnings could be one of the ignored
+            # unreachable label is not reason to fail
             continue #why continue in elif?
 
         elif match "$line" "$MSG_OUR_WARNINGS"; then

--- a/sl/check-property.sh.in
+++ b/sl/check-property.sh.in
@@ -6,7 +6,6 @@ export CCACHE_DISABLE=1
 export MSG_INFLOOP=': warning: end of function .*\(\) has not been reached'
 export MSG_LABEL_FOUND=': error: error label "ERROR" has been reached'
 export MSG_LABEL_UNREACHABLE=': warning: unreachable label .*'
-export MSG_WARNINGS_REPORTED=': warning: Pass has reported some warnings'
 export MSG_VERIFIER_ERROR_FOUND=': (error|warning): __VERIFIER_error\(\) reached'
 export MSG_OUR_WARNINGS=': warning: .*(\[-fplugin=libsl.so\]|\[-sl\])$'
 export MSG_TIME_ELAPSED=': note: clEasyRun\(\) took '
@@ -278,11 +277,9 @@ parse_output() {
             # errors already reported, better to fail now
             fail "$line"
 
-        elif match "$line" "$MSG_INFLOOP"; then
-             match "$line" "$MSG_WARNINGS_REPORTED" || \
-             match "$line" "$MSG_LABEL_UNREACHABLE" || \
+        elif match "$line" "$MSG_INFLOOP" || \
+             match "$line" "$MSG_LABEL_UNREACHABLE"; then
             # infinite loop does not mean FALSE, ignore them
-            # reported warnings could be one of the ignored
             # unreachable label is not reason to fail
             continue #why continue in elif?
 
@@ -320,6 +317,7 @@ if [ -z $ENABLE_LLVM ]; then
     "$GCC_HOST"                                         \
         -fplugin="${SL_PLUG}"                           \
         -fplugin-arg-libsl-args="$ARGS"                 \
+        -fplugin-arg-libsl-preserve-ec                  \
         -o /dev/null -O0 -S -xc "$@" 2>&1               \
         | tee "$TRACE"                                  \
         | parse_output
@@ -330,6 +328,7 @@ else
         -unreachableblockelim                           \
         -load "$PASSES_LIB" -global-vars -nestedgep     \
         -load "$SL_PLUG" -sl -args="$ARGS"              \
+        -preserve-ec                                    \
         -o /dev/null 2>&1                               \
         | tee "$TRACE"                                  \
         | parse_output


### PR DESCRIPTION
LLVM pass `-unreachableblockelim` is not perfect. The script `check-property.sh` returns `UNKNOWN` for `ntdrivers-simplified/kbfiltr_simpl2.cil-1.c`.