### PR TITLE
gcc: more user-friendly diagnostic on gcc version mismatch

### DIFF
--- a/cl/gcc/clplug.c
+++ b/cl/gcc/clplug.c
@@ -139,6 +139,7 @@
 
 #define CL_ERROR(...)   CL_PRINT("error",   __VA_ARGS__)
 #define CL_WARN(...)    CL_PRINT("warning", __VA_ARGS__)
+#define CL_NOTE(...)    CL_PRINT("note",    __VA_ARGS__)
 
 #define CL_DEBUG(...) do {                                                  \
     if (verbose)                                                            \
@@ -2534,17 +2535,14 @@ int plugin_init(struct plugin_name_args *plugin_info,
 
     // print something like "hello world!"
     CL_DEBUG("initializing code listener [SHA1 %s]", CL_GIT_SHA1);
-    CL_DEBUG("plug-in is compiled against gcc %s%s%s, built at %s, conf: %s",
-           gcc_version.basever, gcc_version.devphase, gcc_version.revision,
-           gcc_version.datestamp, gcc_version.configuration_arguments);
-    CL_DEBUG("now going to be loaded into gcc %s%s%s, built at %s, conf: %s",
-           version->basever, version->devphase, version->revision,
-           version->datestamp, version->configuration_arguments);
 
     // check for compatibility with host gcc's version
     if (!plugin_default_version_check(version, &gcc_version)) {
-        CL_ERROR("host gcc's version/build mismatch"
-                 ", call-backs not registered!");
+        CL_ERROR("refusing to be loaded into gcc-%s (%s), built at %s",
+               version->basever, version->devphase, version->datestamp);
+
+        CL_NOTE("plug-in is compiled against gcc-%s (%s), built at %s",
+               gcc_version.basever, gcc_version.devphase, gcc_version.datestamp);
 
         return 1;
     }


### PR DESCRIPTION
If the gcc plug-in refuses to load because of built-time vs. run-time gcc version mismatch, tell the user exactly the gcc versions that were compared.  Prior to this commit the information was printed only when the verbose mode was enabled.