### PR TITLE
fa: make the code compile with gcc-10.2.1

### DIFF
--- a/fa/compiler.cc
+++ b/fa/compiler.cc
@@ -151,6 +151,8 @@ std::string translTypeCode(const unsigned code)
 	}
 }
 
+} // namespace
+
 /**
  * @brief  Translates code of operand types to string
  */
@@ -164,8 +166,6 @@ std::string translOperandCode(const unsigned code)
 		default: throw std::runtime_error("Invalid operand code");
 	}
 }
-
-} // namespace
 
 
 /**

--- a/fa/fixpoint.cc
+++ b/fa/fixpoint.cc
@@ -320,7 +320,7 @@ struct CopyNonZeroRhsF
 	}
 };
 
-
+#if 0
 void getCandidates(
 	std::set<size_t>&               candidates,
 	const FAE&                      fae)
@@ -348,6 +348,7 @@ void getCandidates(
 			candidates.insert(tmp.second.begin(), tmp.second.end());
 	}
 }
+#endif
 
 void learn1(FAE& fae, BoxMan& boxMan)
 {

--- a/fa/folding.cc
+++ b/fa/folding.cc
@@ -123,7 +123,7 @@ void computeSelectorMapTrans(
 	}
 }
 
-
+#if 0
 /**
  * @brief  Checks whether two cutpoint signatures are compatible
  *
@@ -158,7 +158,7 @@ bool isSignaturesCompatible(
 
 	return true;
 }
-
+#endif
 
 /**
  * @brief  Extracts a selector leading to given cutpoint
@@ -297,7 +297,7 @@ bool Folding::discover1(
 
 	if (forbidden.count(root))
 	{	// in the case the root is not to be folded
-		return nullptr;
+		return false;
 	}
 
 	bool found = false;
@@ -353,7 +353,7 @@ bool Folding::discover2(
 
 	if (forbidden.count(root))
 	{	// in the case the root is not to be folded
-		return nullptr;
+		return false;
 	}
 
 	bool found = false;
@@ -428,7 +428,7 @@ bool Folding::discover3(
 
 	if (forbidden.count(root))
 	{	// in the case the root is not to be folded
-		return nullptr;
+		return false;
 	}
 
 	bool found = false;

--- a/fa/forestaut.cc
+++ b/fa/forestaut.cc
@@ -21,6 +21,7 @@
 #include "streams.hh"
 #include "tatimint.hh"
 
+#if 0
 // anonymous namespace
 namespace
 {
@@ -34,7 +35,7 @@ size_t getLabelArity(std::vector<const AbstractBox*>& label)
 	return arity;
 }
 } // namespace
-
+#endif
 
 void FA::reorderBoxes(
 	std::vector<const AbstractBox*>&     label,

--- a/fa/programconfig.hh
+++ b/fa/programconfig.hh
@@ -20,6 +20,9 @@
 #ifndef _PROGRAMCONFIG_HH_
 #define _PROGRAMCONFIG_HH_
 
+// C++ headers
+#include <vector>
+
 // Boost headers
 #include <boost/algorithm/string.hpp>
 

--- a/fa/streams.hh
+++ b/fa/streams.hh
@@ -52,7 +52,7 @@
 	                                                            \
 	std::ostringstream strMsg;                                  \
 	strMsg << to_stream;                                        \
-	if (!(loc))                                                 \
+	if ((loc) == 0)                                             \
 	{                                                           \
 	  std::ostringstream strLoc;                                \
 	  strLoc << locStream;                                      \


### PR DESCRIPTION
This commit fixes the following warnings and errors:
```
Error: COMPILER_WARNING:
fa/compiler.cc: scope_hint: At global scope
fa/compiler.cc:157:13: warning[-Wunused-function]: ‘std::string {anonymous}::translOperandCode(unsigned int)’ defined but not used

Error: COMPILER_WARNING:
fa/fixpoint.cc: scope_hint: At global scope
fa/fixpoint.cc:324:6: warning[-Wunused-function]: ‘void {anonymous}::getCandidates(std::set<long unsigned int>&, const FAE&)’ defined but not used

Error: COMPILER_WARNING:
fa/folding.cc: scope_hint: At global scope
fa/folding.cc:137:6: warning[-Wunused-function]: ‘bool {anonymous}::isSignaturesCompatible(const CutpointSignature&, const CutpointSignature&)’ defined but not used

Error: COMPILER_WARNING:
fa/folding.cc: scope_hint: In member function ‘bool Folding::discover1(size_t, const std::set<long unsigned int>&, bool)’
fa/folding.cc:300:10: error: converting to ‘bool’ from ‘std::nullptr_t’ requires direct-initialization [-fpermissive]

Error: COMPILER_WARNING:
fa/folding.cc: scope_hint: In member function ‘bool Folding::discover2(size_t, const std::set<long unsigned int>&, bool)’
fa/folding.cc:356:10: error: converting to ‘bool’ from ‘std::nullptr_t’ requires direct-initialization [-fpermissive]

Error: COMPILER_WARNING:
fa/folding.cc: scope_hint: In member function ‘bool Folding::discover3(size_t, const std::set<long unsigned int>&, bool)’
fa/folding.cc:431:10: error: converting to ‘bool’ from ‘std::nullptr_t’ requires direct-initialization [-fpermissive]

Error: COMPILER_WARNING:
fa/forestaut.cc:27:8: warning[-Wunused-function]: ‘size_t {anonymous}::getLabelArity(std::vector<const AbstractBox*>&)’ defined but not used

Error: COMPILER_WARNING:
fa/programconfig.cc: scope_hint: In member function ‘void ProgramConfig::processArg(const string&)’
fa/programconfig.cc:30:7: error: ‘vector’ is not a member of ‘std’
fa/programconfig.cc:22:1: note: ‘std::vector’ is defined in header ‘<vector>’; did you forget to ‘#include <vector>’?

Error: COMPILER_WARNING:
fa/programconfig.cc:30:20: error: expected primary-expression before ‘>’ token

Error: COMPILER_WARNING:
fa/programconfig.cc:30:22: error: ‘data’ was not declared in this scope

Error: COMPILER_WARNING:
fa/cl_fa.cc:31: included_from: Included from here.
fa/programconfig.hh: scope_hint: In constructor ‘ProgramConfig::ProgramConfig(const string&)’
fa/programconfig.hh:54:8: error: ‘vector’ is not a member of ‘std’
fa/programconfig.hh:28:1: note: ‘std::vector’ is defined in header ‘<vector>’; did you forget to ‘#include <vector>’?

Error: COMPILER_WARNING:
fa/programconfig.hh:54:26: error: expected primary-expression before ‘>’ token

Error: COMPILER_WARNING:
fa/programconfig.hh:54:28: error: ‘args’ was not declared in this scope

Error: COMPILER_WARNING:
fa/symctx.hh:34: included_from: Included from here.
fa/compiler.cc:40: included_from: Included from here.
fa/symctx.hh: scope_hint: In constructor ‘SymCtx::SymCtx(const CodeStorage::Fnc&, const var_map_type*)’
fa/streams.hh:55:11: error: converting to ‘bool’ from ‘std::nullptr_t’ requires direct-initialization [-fpermissive]
fa/streams.hh:93:2: note: in expansion of macro ‘FA_MSG_STREAM’
fa/streams.hh:124:2: note: in expansion of macro ‘FA_MSG_STREAM_INTERNAL’
fa/symctx.hh:224:7: note: in expansion of macro ‘FA_NOTE’
```