### PR TITLE
sl: use the DCAST macro not only in symheap code

### DIFF
--- a/cl/util.hh
+++ b/cl/util.hh
@@ -36,6 +36,13 @@
         return false;                           \
 } while (0)
 
+#ifdef NDEBUG
+    // aggressive optimization
+#   define DCAST static_cast
+#else
+#   define DCAST dynamic_cast
+#endif
+
 template <typename T>
 void swapValues(T &a, T &b)
 {

--- a/sl/adt_op_replace.cc
+++ b/sl/adt_op_replace.cc
@@ -740,7 +740,7 @@ bool tryReplaceCond(
     str << "?cond" << ctx.condVar;
     TGenericVarSet live;
     live.insert(GenericVar(VL_COND_VAR, condVar));
-    AnnotatedInsn *oldInsn = dynamic_cast<AnnotatedInsn *>(locState.insn);
+    AnnotatedInsn *oldInsn = DCAST<AnnotatedInsn *>(locState.insn);
     GenericInsn *insn = new TextInsn(str.str(), live, oldInsn->killVars());
     pInsnWriter->replaceInsn(loc, insn);
 

--- a/sl/fixed_point.cc
+++ b/sl/fixed_point.cc
@@ -625,11 +625,11 @@ void analyzeLiveVars(
         TLocData &locData = data[locIdx];
         TVarSet &killSet = locData.kill;
 
-        const AnnotatedInsn *insn = dynamic_cast<AnnotatedInsn *>(locNode.insn);
-        if (!insn)
+        if (!locNode.insn)
             // an already removed instruction
             continue;
 
+        const AnnotatedInsn *insn = DCAST<AnnotatedInsn *>(locNode.insn);
         locData.gen = insn->liveVars();
         locData.kill = insn->killVars();
 

--- a/sl/syments.hh
+++ b/sl/syments.hh
@@ -22,16 +22,11 @@
 
 #include "config.h"
 
+#include "util.hh"
+
 #include <vector>
 
 #include <boost/foreach.hpp>
-
-#ifdef NDEBUG
-    // aggressive optimization
-#   define DCAST static_cast
-#else
-#   define DCAST dynamic_cast
-#endif
 
 #if SH_COPY_ON_WRITE
 class RefCounter {

--- a/sl/symheap.cc
+++ b/sl/symheap.cc
@@ -808,7 +808,7 @@ bool SymHeapCore::Private::chkValueDeps(const TValId val)
         return true;
 
     const InternalCustomValue *customData =
-        DCAST<const InternalCustomValue *>(valData);
+        dynamic_cast<const InternalCustomValue *>(valData);
 
     if (CV_INT_RANGE != customData->customData.code())
         // we are interested only in CV_INT_RANGE here

--- a/sl/symheap.cc
+++ b/sl/symheap.cc
@@ -808,7 +808,7 @@ bool SymHeapCore::Private::chkValueDeps(const TValId val)
         return true;
 
     const InternalCustomValue *customData =
-        dynamic_cast<const InternalCustomValue *>(valData);
+        DCAST<const InternalCustomValue *>(valData);
 
     if (CV_INT_RANGE != customData->customData.code())
         // we are interested only in CV_INT_RANGE here


### PR DESCRIPTION
With some luck, using `static_cast` instead of `dynamic_cast` (where the code knows in advance which type of object it expects), the optimization may hide some bugs in production while keeping them visible in a debug build.  Of course, we cannot replace uses of `dynamic_cast` where the code actually checks type of the target object.

This optimization is known to eliminate crashes on Mac reported at: https://github.com/kdudka/predator/pull/49

... although root cause of the crashes is still unknown.

Closes: https://github.com/kdudka/predator/pull/51