### PR TITLE
cl/gcc: relax the check for compatibility with host GCC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,10 @@ matrix:
         - name: switch-host-gcc/gcc-10
           dist: focal
           install:
+              # work around broken Ubuntu 20 LTS images
+              # cause: https://travis-ci.community/t/build-suddenly-starting-to-error-out-unmet-package-dependencies/8182
+              # solution: https://github.com/OpenSC/OpenSC/pull/2331
+              - sudo apt-get install -yq --allow-downgrades libc6=2.31-0ubuntu9.2 libc6-dev=2.31-0ubuntu9.2
               - sudo apt-get install cmake g++-10-multilib gcc-10-plugin-dev gcc-multilib libboost-dev
           env:
               - CC=/usr/bin/gcc-10
@@ -89,7 +93,7 @@ matrix:
 
 
         - name: switch-host-llvm/llvm-10
-          dist: focal
+          dist: bionic
           install:
               - sudo apt-get install clang-10 cmake llvm-10-dev gcc-multilib libboost-dev
           env:

--- a/cl/gcc/clplug.c
+++ b/cl/gcc/clplug.c
@@ -2524,6 +2524,15 @@ static bool write_pid_file(const char *pid_file)
     return true;
 }
 
+static bool simplified_version_check(
+        const struct plugin_gcc_version *a,
+        const struct plugin_gcc_version *b)
+{
+    // compare only base GCC version, so that we do not need to rebuild
+    // predator on each update of GCC
+    return STREQ(a->basever, b->basever);
+}
+
 // plug-in initialization according to gcc plug-in API
 __attribute__ ((__visibility__ ("default")))
 int plugin_init(struct plugin_name_args *plugin_info,
@@ -2545,7 +2554,7 @@ int plugin_init(struct plugin_name_args *plugin_info,
     CL_DEBUG("initializing code listener [SHA1 %s]", CL_GIT_SHA1);
 
     // check for compatibility with host gcc's version
-    if (!plugin_default_version_check(version, &gcc_version)) {
+    if (!simplified_version_check(version, &gcc_version)) {
         CL_ERROR("refusing to be loaded into gcc-%s (%s), built at %s",
                version->basever, version->devphase, version->datestamp);
 


### PR DESCRIPTION
... so that we do not need to rebuild predator on each update of GCC