### PR TITLE
sl/symdump: silence false positives produced by clang

### DIFF
--- a/sl/cl_symexec.cc
+++ b/sl/cl_symexec.cc
@@ -165,7 +165,7 @@ void launchSymExec(const CodeStorage::Storage &stor)
 // see easy.hh for details
 void clEasyRun(const CodeStorage::Storage &stor, const char *configString)
 {
-    initSymDump();
+    initSymDump(stor);
 
     // read parameters of symbolic execution
     GlConf::loadConfigString(configString);

--- a/sl/symdump.cc
+++ b/sl/symdump.cc
@@ -74,18 +74,19 @@ void sl_dump(Trace::Node *endPoint)
 }
 
 /// dummy function to pull all symbols from a static library
-void initSymDump(int i)
+void initSymDump(TStorRef stor, int i)
 {
     if (!i)
         return;
 
-    sl_dump((const SymHeapCore *) 0);
-    sl_dump(*(const SymHeapCore *) 0);
-    sl_dump(*(const SymHeapCore *) 0, (const char *) 0);
-    sl_dump((Trace::Node *) 0);
+    const SymHeapCore sh(stor, 0);
+    sl_dump(&sh);
+    sl_dump(sh);
+    sl_dump(sh, static_cast<const char *>(0));
+    sl_dump(static_cast<Trace::Node *>(0));
 }
 
-void initSymDump()
+void initSymDump(TStorRef stor)
 {
-    initSymDump(0);
+    initSymDump(stor, 0);
 }

--- a/sl/symdump.hh
+++ b/sl/symdump.hh
@@ -30,12 +30,16 @@
 class SymHeap;
 class SymHeapCore;
 
+namespace CodeStorage {
+    struct Storage;
+}
+
 namespace Trace {
     class Node;
 }
 
 /// dummy function to pull all symbols from a static library
-void initSymDump();
+void initSymDump(const CodeStorage::Storage &);
 
 /// plot the given heap to file "symdump-NNNN.dot"
 void sl_dump(const SymHeapCore *sh);


### PR DESCRIPTION
```
sl/symdump.cc:83:13: warning: binding dereferenced null pointer to reference has undefined behavior [-Wnull-dereference]
    sl_dump(*(const SymHeapCore *) 0);
            ^~~~~~~~~~~~~~~~~~~~~~~~
sl/symdump.cc:84:13: warning: binding dereferenced null pointer to reference has undefined behavior [-Wnull-dereference]
    sl_dump(*(const SymHeapCore *) 0, (const char *) 0);
            ^~~~~~~~~~~~~~~~~~~~~~~~
```
Reported-by: Lukas Zaoral
Closes: https://github.com/kdudka/predator/pull/54