### PR TITLE
cl/CMakeLists.txt: pass the gcc include directory as a system one

### DIFF
--- a/cl/CMakeLists.txt
+++ b/cl/CMakeLists.txt
@@ -154,7 +154,7 @@ endif()
 
 # set the path to GCC headers for building plug-ins
 set_source_files_properties(gcc/clplug.c PROPERTIES
-    COMPILE_FLAGS "-I${GCC_INC_DIR}")
+    COMPILE_FLAGS "-isystem ${GCC_INC_DIR}")
 
 endif() # ----------------------------------------------------------------end
 


### PR DESCRIPTION
Otherwise, compilers would produce warnings in headers that are not
under our control.