### PR TITLE
fix undefined behavior at multiple places

### DIFF
--- a/cl/Makefile.chk
+++ b/cl/Makefile.chk
@@ -20,7 +20,7 @@ CXX_HEADERS ?= *.hh
 
 SINK ?= /dev/null
 
-CXXFLAGS += -pedantic -Wall -Wextra -Wno-variadic-macros -Werror -I../include
+CXXFLAGS += -std=c++11 -pedantic -Wall -Wextra -Wno-variadic-macros -Werror -I../include
 
 .PHONY: check $(C_HEADERS) $(CXX_HEADERS)
 

--- a/cl/storage.cc
+++ b/cl/storage.cc
@@ -90,15 +90,6 @@ namespace {
     }
 }
 
-Var::Var():
-    code(VAR_VOID)
-{
-}
-
-Var::~Var()
-{
-}
-
 Var::Var(EVar code_, const struct cl_operand *op):
     code(code_),
     loc(op->data.var->loc),

--- a/include/cl/storage.hh
+++ b/include/cl/storage.hh
@@ -61,20 +61,20 @@ enum EVar {
  * high-level variable representation
  */
 struct Var {
-    EVar                        code;   ///< high-level kind of variable
-    struct cl_loc               loc;    ///< location of its declaration
+    EVar            code = VAR_VOID;        ///< high-level kind of variable
+    struct cl_loc   loc = cl_loc_unknown;   ///< location of its declaration
 
     /**
      * type of the variable
      * @note This often differs from type of the operand given to constructor!
      */
-    const struct cl_type        *type;
+    const struct cl_type        *type = nullptr;
 
     /**
      * unique ID of variable
      * @attention not guaranteed to be unique beyond the scope of variable
      */
-    cl_uid_t                    uid;
+    cl_uid_t                    uid = -1;
 
     /**
      * name of the variable, empty string for anonymous variables
@@ -93,25 +93,20 @@ struct Var {
      *
      * @todo a better API for initializers?
      */
-    bool                        initialized;
+    bool                        initialized = false;
 
     /**
      * true if the variable is external (defined in another module)
      */
-    bool                        isExtern;
+    bool                        isExtern = false;
 
     /**
      * true if there is at least one instruction in the program that takes an
      * address of the variable (or some part of it)
      */
-    bool                        mayBePointed;
+    bool                        mayBePointed = false;
 
-    /**
-     * dummy constructor
-     * @note known to be useful for internal purposes only
-     */
-    Var();
-    ~Var();
+    Var() = default;
 
     /**
      * wrap low-level operand to Var object

--- a/sl/symheap.cc
+++ b/sl/symheap.cc
@@ -573,7 +573,7 @@ class CustomValueMapper {
         TCustomByNum        numMap;
         TCustomByReal       fpnMap;
         TCustomByString     strMap;
-        TValId              inval_;
+        TValId              inval_ = VAL_INVALID;
 
     public:
         RefCounter          refCnt;

--- a/sl/symheap.cc
+++ b/sl/symheap.cc
@@ -174,6 +174,12 @@ class CVarMap {
 
 // /////////////////////////////////////////////////////////////////////////////
 // implementation of CustomValue
+CustomValue::CustomValue():
+    code_(CV_INVALID)
+{
+    std::memset(&data_, 0, sizeof data_);
+}
+
 CustomValue::~CustomValue()
 {
     if (CV_STRING != code_)

--- a/sl/symheap.hh
+++ b/sl/symheap.hh
@@ -690,7 +690,11 @@ class FldHandle {
         TOffset         offset()        const { return sh_->fieldOffset(id_); }
 
         /// return the value inside the field (may trigger its initialization)
-        TValId          value()         const { return sh_->valueOf(id_); }
+        TValId          value()         const {
+            return (this->isValidHandle())
+                ? sh_->valueOf(id_)
+                : VAL_INVALID;
+        }
 
         /// return the address of the field (may trigger address instantiation)
         TValId          placedAt()      const { return sh_->placedAt(id_); }

--- a/sl/symheap.hh
+++ b/sl/symheap.hh
@@ -116,12 +116,7 @@ union CustomValueData {
 /// representation of a custom value, such as integer literal, or code pointer
 class CustomValue {
     public:
-        // cppcheck-suppress uninitVar
-        CustomValue():
-            code_(CV_INVALID)
-        {
-        }
-
+        CustomValue();
         ~CustomValue();
         CustomValue(const CustomValue &);
         CustomValue& operator=(const CustomValue &);

--- a/sl/symjoin.cc
+++ b/sl/symjoin.cc
@@ -588,7 +588,10 @@ bool joinCustomValues(
     // compute the resulting range that covers both
     IR::Range rng = join(rng1, rng2);
 
-    if (GlConf::data.intArithmeticLimit) {
+    if (GlConf::data.intArithmeticLimit
+            // avoid integer overflow on std::abs(IR::IntMin)
+            && (IR::IntMin != rng.lo) && (IR::IntMax != rng.hi))
+    {
         const IR::TInt max = std::max(std::abs(rng.lo), std::abs(rng.hi));
         if (max <= GlConf::data.intArithmeticLimit)
             // integral values preserved by SE_INT_ARITHMETIC_LIMIT


### PR DESCRIPTION
cl/storage: always fully initialize Var objects

If we only initialize `code = VAR_VOID` it triggers UB sanitizer reports when Var objects are copied in dbLookup():
```
    $ LD_PRELOAD=/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/libasan.so.6 ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=1 /usr/bin/gcc -S -O0 -I/var/tmp/git/predator/sl_build/../include/predator-builtins -DPREDATOR -o /dev/null -fplugin=/var/tmp/git/predator/sl_build/libsl.so -fplugin-arg-libsl-pid-file=/tmp/slscript.XXcvpY -fplugin-arg-libsl-args=error_label:ERROR ../tests/predator-regre/test-0045.c
    /var/tmp/git/predator/include/cl/storage.hh:63:8: runtime error: load of value 144, which is not a valid value for type 'bool'
        #0 0x7f89bc868f1b in CodeStorage::Var::Var(CodeStorage::Var const&) /var/tmp/git/predator/include/cl/storage.hh:63
        #1 0x7f89bc868f1b in void __gnu_cxx::new_allocator<CodeStorage::Var>::construct<CodeStorage::Var, CodeStorage::Var const&>(CodeStorage::Var*, CodeStorage::Var const&) /usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/include/g++-v10/ext/new_allocator.h:150
        #2 0x7f89bc868f1b in void std::allocator_traits<std::allocator<CodeStorage::Var> >::construct<CodeStorage::Var, CodeStorage::Var const&>(std::allocator<CodeStorage::Var>&, CodeStorage::Var*, CodeStorage::Var const&) /usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/include/g++-v10/bits/alloc_traits.h:512
        #3 0x7f89bc868f1b in void std::vector<CodeStorage::Var, std::allocator<CodeStorage::Var> >::_M_realloc_insert<CodeStorage::Var const&>(__gnu_cxx::__normal_iterator<CodeStorage::Var*, std::vector<CodeStorage::Var, std::allocator<CodeStorage::Var> > >, CodeStorage::Var const&) /usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/include/g++-v10/bits/vector.tcc:449
        #4 0x7f89bc85fdfd in std::vector<CodeStorage::Var, std::allocator<CodeStorage::Var> >::push_back(CodeStorage::Var const&) /usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/include/g++-v10/bits/stl_vector.h:1198
        #5 0x7f89bc85fdfd in dbLookup<std::map<long int, unsigned int>, std::vector<CodeStorage::Var>, long int> /var/tmp/git/predator/cl/storage.cc:58
        #6 0x7f89bc85fdfd in CodeStorage::VarDb::operator[](long) /var/tmp/git/predator/cl/storage.cc:182
        #7 0x7f89bc751135 in ClStorageBuilder::Private::digOperandVar(cl_operand const*, bool) /var/tmp/git/predator/cl/cl_storage.cc:413
        #8 0x7f89bc7542a2 in ClStorageBuilder::fnc_arg_decl(int, cl_operand const*) /var/tmp/git/predator/cl/cl_storage.cc:614
        #9 0x7f89bc623757 in cl_wrap_fnc_arg_decl /var/tmp/git/predator/cl/code_listener.cc:246
        #10 0x7f89bc61c80b in ClChain::fnc_arg_decl(int, cl_operand const*) /var/tmp/git/predator/cl/cl_chain.cc:137
        #11 0x7f89bc623757 in cl_wrap_fnc_arg_decl /var/tmp/git/predator/cl/code_listener.cc:246
        #12 0x7f89bc611a59 in handle_fnc_decl_arglist /var/tmp/git/predator/cl/gcc/clplug.c:2140
        #13 0x7f89bc611a59 in handle_fnc_decl /var/tmp/git/predator/cl/gcc/clplug.c:2158
        #14 0x7f89bc611a59 in cl_pass_execute /var/tmp/git/predator/cl/gcc/clplug.c:2191
        #15 0x7f89bc611a59 in cl_pass_str::execute(function*) /var/tmp/git/predator/cl/gcc/clplug.c:2217
        #16 0xa50bb7 in execute_one_pass(opt_pass*) (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0xa50bb7)
        #17 0xa514ef  (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0xa514ef)
        #18 0xa51528 in execute_pass_list(function*, opt_pass*) (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0xa51528)
        #19 0x7356aa in cgraph_node::analyze() (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x7356aa)
        #20 0x7382ff  (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x7382ff)
        #21 0x738ef2 in symbol_table::finalize_compilation_unit() (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x738ef2)
        #22 0xb15ae0  (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0xb15ae0)
        #23 0x5ddde9 in toplev::main(int, char**) (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x5ddde9)
        #24 0x5e192b in main (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x5e192b)
        #25 0x7f89c184780c in __libc_start_main (/lib64/libc.so.6+0x2380c)
        #26 0x5e3649 in _start (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x5e3649)
```
sl/symjoin: avoid integer overflow on std::abs(IR::IntMin)

... which was observable by UB sanitizer:
```
    $ LD_PRELOAD=/usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/libasan.so.6 ASAN_OPTIONS=detect_leaks=0 UBSAN_OPTIONS=print_stacktrace=1 /usr/bin/gcc -S -O0 -I/var/tmp/git/predator/sl_build/../include/predator-builtins -DPREDATOR -o /dev/null -fplugin=/var/tmp/git/predator/sl_build/libsl.so -fplugin-arg-libsl-pid-file=/tmp/slscript.XXcvpY -fplugin-arg-libsl-args=error_label:ERROR ../tests/predator-regre/test-0045.c
    /usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/include/g++-v10/bits/std_abs.h:56:44: runtime error: negation of -9223372036854775808 cannot be represented in type 'long int'; cast to an unsigned type to negate this value to itself
        #0 0x7f90dd7cc56a in std::abs(long) /usr/lib/gcc/x86_64-pc-linux-gnu/10.3.0/include/g++-v10/bits/std_abs.h:56
        #1 0x7f90dd79789b in joinCustomValues(SymJoinCtx&, SchedItem const&) /var/tmp/git/predator/sl/symjoin.cc:592
        #2 0x7f90dd799513 in joinValuesByCode(bool*, SymJoinCtx&, SchedItem const&) /var/tmp/git/predator/sl/symjoin.cc:699
        #3 0x7f90dd7c19b6 in joinValuePair(SymJoinCtx&, SchedItem const&) /var/tmp/git/predator/sl/symjoin.cc:2362
        #4 0x7f90dd7c2996 in joinPendingValues(SymJoinCtx&) /var/tmp/git/predator/sl/symjoin.cc:2413
        #5 0x7f90dd7c7cbf in joinSymHeaps(EJoinStatus*, SymHeap*, SymHeap, SymHeap, bool) /var/tmp/git/predator/sl/symjoin.cc:2587
        #6 0x7f90dd469573 in SymStateWithJoin::insert(SymHeap const&, bool) /var/tmp/git/predator/sl/symstate.cc:302
        #7 0x7f90dd22956a in SymExecEngine::joinCallResults() /var/tmp/git/predator/sl/symexec.cc:807
        #8 0x7f90dd22a01b in SymExecEngine::run() /var/tmp/git/predator/sl/symexec.cc:819
        #9 0x7f90dd23ad5c in SymExec::execFnc(SymState&, SymHeap const&, CodeStorage::Insn const&, CodeStorage::Fnc const&) /var/tmp/git/predator/sl/symexec.cc:1221
        #10 0x7f90dd23d655 in execTopCall(SymState&, SymHeap const&, CodeStorage::Insn const&, CodeStorage::Fnc const&) /var/tmp/git/predator/sl/symexec.cc:1303
        #11 0x7f90dd23eb93 in execute(SymState&, SymHeap const&, CodeStorage::Fnc const&) /var/tmp/git/predator/sl/symexec.cc:1332
        #12 0x7f90dd12386a in execFnc(CodeStorage::Fnc const&, bool) /var/tmp/git/predator/sl/cl_symexec.cc:97
        #13 0x7f90dd1269a4 in launchSymExec(CodeStorage::Storage const&) /var/tmp/git/predator/sl/cl_symexec.cc:160
        #14 0x7f90dd126f35 in clEasyRun(CodeStorage::Storage const&, char const*) /var/tmp/git/predator/sl/cl_symexec.cc:175
        #15 0x7f90dcf74d0a in ClEasy::run(CodeStorage::Storage&) /var/tmp/git/predator/cl/cl_easy.cc:82
        #16 0x7f90dce58969 in cl_wrap_acknowledge /var/tmp/git/predator/cl/code_listener.cc:319
        #17 0x7f90dce5670d in ClChain::acknowledge() /var/tmp/git/predator/cl/cl_chain.cc:200
        #18 0x7f90dce58969 in cl_wrap_acknowledge /var/tmp/git/predator/cl/code_listener.cc:319
        #19 0x7f90dce3941e in cb_finish /var/tmp/git/predator/cl/gcc/clplug.c:2245
        #20 0xa59141 in invoke_plugin_callbacks_full(int, void*) (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0xa59141)
        #21 0x5ddf29 in toplev::main(int, char**) (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x5ddf29)
        #22 0x5e192b in main (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x5e192b)
        #23 0x7f90e207e80c in __libc_start_main (/lib64/libc.so.6+0x2380c)
        #24 0x5e3649 in _start (/usr/libexec/gcc/x86_64-pc-linux-gnu/10.3.0/cc1+0x5e3649)
```
    This was also breaking test-0045.c in the test-suite with clang-12.

    Reported-by: Lukas Zaoral
    Fixes: https://github.com/kdudka/predator/issues/55
    Closes: https://github.com/kdudka/predator/pull/57