### PR TITLE
llvm: fix use of uninitialized value in CLPass::handleGEPOperand()

### DIFF
--- a/cl/llvm/clplug.cc
+++ b/cl/llvm/clplug.cc
@@ -2181,6 +2181,7 @@ bool CLPass::handleGEPOperand(Value *v, struct cl_operand *src) {
             case CL_TYPE_PTR: {
                 //                errs() << "ptr ";
                 // offset: constant, possible variable
+                acc->code = CL_ACCESSOR_DEREF;
                 int num = 0;
                 if (isa<ConstantInt>(v)) {
                     num = cast<ConstantInt>(v)->getValue().getSExtValue();
@@ -2195,7 +2196,6 @@ bool CLPass::handleGEPOperand(Value *v, struct cl_operand *src) {
                         addrNextAcc = &(src->accessor);
                         continue; // no accessor
                     }
-                    acc->code = CL_ACCESSOR_DEREF;
 
                     if (num != 0) { // + constant offset
                         addrNextAcc = &(acc->next);
@@ -2211,7 +2211,6 @@ bool CLPass::handleGEPOperand(Value *v, struct cl_operand *src) {
                     // TODO: Code Listener offset as cl_operand
                     src = insertOffsetAcc(v, src);
                     src->type = const_cast<struct cl_type *>(src->type->items[0].type);
-                    acc->code = CL_ACCESSOR_DEREF;
                 }
 
             }


### PR DESCRIPTION
... by initializing `acc->code` before `freeAccessor()` is called on it

```
cl/llvm/clplug.cc:311:45: runtime error: load of value 3200171710, which is not a valid value for type 'cl_accessor_e'
    #0 0x7fc12a6c3f3d in CLPass::freeAccessor(cl_accessor*) [clone .cold] (/var/tmp/git/predator/sl_build/libsl.so+0xc8ff3d)
    #1 0x7fc12a7ba941 in CLPass::handleGEPOperand(llvm::Value*, cl_operand*) (/var/tmp/git/predator/sl_build/libsl.so+0xd86941)
    #2 0x7fc12a7bd3f2 in CLPass::handleUnaryInstruction(llvm::Instruction*) (/var/tmp/git/predator/sl_build/libsl.so+0xd893f2)
    #3 0x7fc12a7bf209 in CLPass::handleInstruction(llvm::Instruction*) (/var/tmp/git/predator/sl_build/libsl.so+0xd8b209)
    #4 0x7fc12a7c5424 in CLPass::handleOperand(llvm::Value*, cl_operand*) (/var/tmp/git/predator/sl_build/libsl.so+0xd91424)
    #5 0x7fc12a7dfdba in CLPass::handleCallInstruction(llvm::CallInst*) (/var/tmp/git/predator/sl_build/libsl.so+0xdabdba)
    #6 0x7fc12a7c2272 in CLPass::handleInstruction(llvm::Instruction*) (/var/tmp/git/predator/sl_build/libsl.so+0xd8e272)
    #7 0x7fc12a7e5cd9 in CLPass::runOnModule(llvm::Module&) (/var/tmp/git/predator/sl_build/libsl.so+0xdb1cd9)
    #8 0x7fc130d1aa52 in llvm::legacy::PassManagerImpl::run(llvm::Module&) (/usr/lib/llvm/14/bin/../lib64/libLLVM-14.so+0xf83a52)
    #9 0x563fb3fc5704 in main (/usr/lib/llvm/14/bin/opt+0x25704)
    #10 0x7fc12f97f339 in __libc_start_call_main (/lib64/libc.so.6+0x29339)
    #11 0x7fc12f97f3eb in __libc_start_main_alias_1 (/lib64/libc.so.6+0x293eb)
    #12 0x563fb3fc63f0 in _start (/usr/lib/llvm/14/bin/opt+0x263f0)
```