### PR TITLE
symtrace: avoid stack overflow on complex trace graphs

### DIFF
--- a/sl/symtrace.hh
+++ b/sl/symtrace.hh
@@ -189,6 +189,8 @@ class NodeHandle: public NodeBase {
             ref->notifyBirth(this);
         }
 
+        virtual ~NodeHandle();
+
         /// return the node stored within this handle
         Node* node() const {
             return this->parent();


### PR DESCRIPTION
... by traversing the graphs using containers allocated on heap rather than excessive recursive calls through trace node destructors.