### PR TITLE
symtrace: make the trace graph cleanup work again

### DIFF
--- a/sl/symtrace.cc
+++ b/sl/symtrace.cc
@@ -187,12 +187,12 @@ void replaceNode(Node *tr, Node *by)
 // /////////////////////////////////////////////////////////////////////////////
 // implementation of Trace::NodeHandle
 
-template <class TNodeKind> bool isNodeKindReachble(Node *const);
+template <class TNodeKind> bool isNodeKindReachable(Node *const);
 
 NodeHandle::~NodeHandle()
 {
 #ifndef NDEBUG
-    (void) isNodeKindReachble<RootNode>(this->parent());
+    (void) isNodeKindReachable<RootNode>(this->parent());
 #endif
     this->parent()->notifyDeath(this);
 }
@@ -732,7 +732,7 @@ void printTrace(Node *endPoint)
 // implementation of Trace::chkTraceGraphConsistency()
 
 template <class TNodeKind>
-bool isNodeKindReachble(Node *const from)
+bool isNodeKindReachable(Node *const from)
 {
     Node *node = from;
     WorkList<Node *> wl(node);
@@ -752,18 +752,18 @@ bool isNodeKindReachble(Node *const from)
 
 bool chkTraceGraphConsistency(Node *const from)
 {
-    if (isNodeKindReachble<CloneNode>(from)) {
+    if (isNodeKindReachable<CloneNode>(from)) {
         CL_WARN("CloneNode reachable from the given trace graph node");
         plotTrace(from, "symtrace-CloneNode-reachable");
     }
 
-    if (!isNodeKindReachble<RootNode>(from)) {
+    if (!isNodeKindReachable<RootNode>(from)) {
         CL_ERROR("RootNode not reachable from the given trace graph node");
         plotTrace(from, "symtrace-RootNode-not-reachable");
         return false;
     }
 
-    if (isNodeKindReachble<TransientNode>(from)) {
+    if (isNodeKindReachable<TransientNode>(from)) {
         CL_ERROR("TransientNode reachable from the given trace graph node");
         plotTrace(from, "symtrace-TransientNode-reachable");
         return false;

--- a/sl/symtrace.cc
+++ b/sl/symtrace.cc
@@ -236,7 +236,7 @@ bool seekAncestor(TNode tr, const TNode trAncestor, const TNodeSet &blackList)
     return false;
 }
 
-bool parentIdxByAncestor(
+int parentIdxByAncestor(
         const TNode                 tr,
         const TNode                 trAncestor,
         const TNodeSet             &blackList)

--- a/sl/symtrace.hh
+++ b/sl/symtrace.hh
@@ -175,6 +175,8 @@ class Node: public NodeBase {
     private:
         TBaseList children_;
         bool alive_;
+
+        template <class TNodeKind> friend bool isNodeKindReachble(Node *const);
 };
 
 void replaceNode(Node *tr, Node *by);

--- a/sl/symtrace.hh
+++ b/sl/symtrace.hh
@@ -176,7 +176,7 @@ class Node: public NodeBase {
         TBaseList children_;
         bool alive_;
 
-        template <class TNodeKind> friend bool isNodeKindReachble(Node *const);
+        template <class TNodeKind> friend bool isNodeKindReachable(Node *const);
 };
 
 void replaceNode(Node *tr, Node *by);


### PR DESCRIPTION
There was a copy/paste mistake in the last commit.  After fixing the
mistake it turned out that the algorithm did not work at all.  This
commit fixes it and inserts a few run-time assertions in a debug build
to catch programming mistakes in the cleanup algorithm early enough.