### PR TITLE
symtrace: do not traverse trace graph in NodeHandle destructor

### DIFF
--- a/sl/symtrace.cc
+++ b/sl/symtrace.cc
@@ -187,13 +187,8 @@ void replaceNode(Node *tr, Node *by)
 // /////////////////////////////////////////////////////////////////////////////
 // implementation of Trace::NodeHandle
 
-template <class TNodeKind> bool isNodeKindReachable(Node *const);
-
 NodeHandle::~NodeHandle()
 {
-#ifndef NDEBUG
-    (void) isNodeKindReachable<RootNode>(this->parent());
-#endif
     this->parent()->notifyDeath(this);
 }
 


### PR DESCRIPTION
It makes the regression tests extremely slow with the debug build of Predator.

Reported-by: Lukas Zaoral
Closes: https://github.com/kdudka/predator/pull/69