### PR TITLE
Add Shell linter - Differential-ShellCheck

### DIFF
--- a/.github/workflows/differential-shellcheck.yml
+++ b/.github/workflows/differential-shellcheck.yml
@@ -1,0 +1,28 @@
+---
+
+name: Differential ShellCheck
+on:
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-22.04
+
+    permissions:
+      security-events: write
+      pull-requests: write
+
+    steps:
+      - name: Repository checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+        with:
+          fetch-depth: 0
+
+      - name: Differential ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@56bbb775a15f66b90ca2d3d44d8269627ed0557d
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/build-aux/cclib.sh
+++ b/build-aux/cclib.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # common code base for sl_build/sl{gcc,gdb,llvm}
 
 die() {

--- a/vra/tests-overall/tests-config.sh.in
+++ b/vra/tests-overall/tests-config.sh.in
@@ -1,3 +1,4 @@
+# shellcheck shell=sh
 #
 # Encoding: utf-8
 # Author:   Daniela Duricekova, xduric00@stud.fit.vutbr.cz

--- a/vra/tests-overall/tests-utils.sh
+++ b/vra/tests-overall/tests-utils.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 #
 # Encoding: utf-8
 # Author:	Daniela Duricekova, xduric00@stud.fit.vutbr.cz


### PR DESCRIPTION
Differential ShellCheck is a GitHub action that performs differential ShellCheck scans on files changed via PR and reports results directly in PR.

Since this repository contains some shell scripts I think you might find it useful.

Documentation is available at: [@redhat-plumbers-in-action/differential-shellcheck](https://github.com/redhat-plumbers-in-action/differential-shellcheck#readme). Let me know If you are missing some feature or setting.

/cc @kdudka 