### PR TITLE
Run `coverity` workflow only on primary repository

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   coverity:
+    if: github.repository == 'kdudka/predator'
     name: Coverity Scan
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
Since `coverity` workflow requires special secrets, it would make sense to disable it for forks.
![Screenshot from 2022-08-09 17-50-19](https://user-images.githubusercontent.com/2879818/183699185-d8d5d536-eb67-46e1-a5de-ec4437df44d5.png)

