### PR TITLE
CI: drop Ubuntu 18.04 jobs

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         compiler: [clang, gcc]
         host: [gcc, llvm]
-        version: [18.04, 20.04, 22.04]
+        version: [20.04, 22.04]
         include:
           - variant: ', variant: expensive tests'
             compiler: gcc
@@ -47,12 +47,6 @@ jobs:
       - name: Determine default tool versions for Ubuntu ${{ matrix. version }}
         run: |
           case '${{ matrix.version }}' in
-            18.04)
-              GCC_HOST_VERSION=7
-              # LLVM 6 is the last release to use minor version
-              # in binary names.
-              LLVM_HOST_VERSION=6.0
-              ;;
             20.04)
               GCC_HOST_VERSION=9
               LLVM_HOST_VERSION=10
@@ -113,10 +107,6 @@ jobs:
             echo "CC=/usr/bin/clang-$LLVM_HOST_VERSION" >> "$GITHUB_ENV"
             echo "CXX=/usr/bin/clang++-$LLVM_HOST_VERSION" >> "$GITHUB_ENV"
           fi
-
-      - name: '[GCC 7] Apply GCC 7 only patch'
-        if: matrix.host == 'gcc' && env.GCC_HOST_VERSION == 7
-        run: patch -p1 < build-aux/gcc-8.3.0.patch
 
       - name: '[Jammy] Add sanitizers to CXXFLAGS'
         if: matrix.version >= 22.04


### PR DESCRIPTION
They are deprecated according to the GitHub Blog [1] and will be removed by
the end of November.

[1] https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/