### PR TITLE
sl: use `std::move()` where appropriate

### DIFF
--- a/sl/cont_shape.cc
+++ b/sl/cont_shape.cc
@@ -261,7 +261,7 @@ bool ImpliedShapeDetector::indexShape(SymHeap &sh, const Shape &shape)
         /* props    */ shape.props,
         /* type     */ sh.objEstimatedType(beg),
         /* size     */ sh.objSize(beg),
-        /* headPtrs */ headPtrs
+        /* headPtrs */ std::move(headPtrs)
     };
     plist_.push_back(sp);
 

--- a/sl/fixed_point_proxy.cc
+++ b/sl/fixed_point_proxy.cc
@@ -386,7 +386,7 @@ void plotFixedPointOfFnc(PlotData &plot, const GlobalState &fncState)
     recorder.flush(&rewriter);
 
     // plot the annotated input CFG
-    plotFncCore(plot, fncState, varByShape, capture, heapSet);
+    plotFncCore(plot, fncState, varByShape, capture, std::move(heapSet));
 
     if (cfgOrig.size() < 16) {
         // plot the original CFG-only subgraph


### PR DESCRIPTION
Suggested by Coverity.