### PR TITLE
ci: use macOS 13 for macOS jobs

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -28,7 +28,7 @@ jobs:
           - variant: ', variant: debug build'
             host: llvm-debug
 
-    runs-on: macos-latest
+    runs-on: macos-13
     env:
       CFLAGS: -Werror
       CXXFLAGS: -Werror


### PR DESCRIPTION
... because predator is not (yet) compatible with arm64 macOS.