### PR TITLE
sl: use `-std=gnu99` to compile test cases

### DIFF
--- a/sl/CMakeLists.txt
+++ b/sl/CMakeLists.txt
@@ -388,6 +388,9 @@ macro(test_predator_regre name_suff ext arg1)
     foreach (num ${tests})
         set(cmd "LC_ALL=C CCACHE_DISABLE=1 ${GCC_EXEC_PREFIX} ${GCC_HOST}")
 
+        # gcc-15 defaults to -std=gnu23 and the tests are not ready for that
+        set(cmd "${cmd} -std=gnu99")
+
         # we use the following flag to avoid differences on 32bit vs 64bit archs
         # in the error output, which is checked for exact match
         set(cmd "${cmd} -m32")

--- a/tests/predator-regre/test-0095.c
+++ b/tests/predator-regre/test-0095.c
@@ -27,7 +27,7 @@ union data {
 
 int main()
 {
-    union data d = {
+    static union data d = {
         .number = 0L
     };
     __VERIFIER_plot(NULL);


### PR DESCRIPTION
They are not ready for `-std=gnu23`, which gcc-15 defaults to.