### PR TITLE
symbin: handle OOM in a call of `strdup()`

### DIFF
--- a/sl/symbin.cc
+++ b/sl/symbin.cc
@@ -666,6 +666,10 @@ bool handlePrintf(
     unsigned opIdx = /* 1st vararg */ 3;
 
     char *fmtAlloc = strdup(fmtStr.c_str());
+    if (!fmtAlloc)
+        // out of memory
+        throw std::bad_alloc();
+
     const char *fmt = fmtAlloc;
     while (*fmt) {
         if ('%' != *(fmt++))


### PR DESCRIPTION
Detected by Cppcheck through OSH/Packit:
https://openscanhub.fedoraproject.org/task/44500/log/predator-0.1.0.20250320.093432.gb367a8d3.pr_106-1/scan-results.html

```
Error: CPPCHECK_WARNING (CWE-476):
predator-0.1.0.20250320.093432.gb367a8d3.pr_106-build/predator-0.1.0.20250320.093432.gb367a8d3.pr_106/sl/symbin.cc:670: warning[nullPointerOutOfMemory]: If memory allocation fails, then there is a possible null pointer dereference: fmt
 #  668|       char *fmtAlloc = strdup(fmtStr.c_str());
 #  669|       const char *fmt = fmtAlloc;
 #  670|->     while (*fmt) {
 #  671|           if ('%' != *(fmt++))
 #  672|               continue;
```