### PR TITLE
cmake: raise minimum required version to 3.5

### DIFF
--- a/cl/CMakeLists.txt
+++ b/cl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2012 Kamil Dudka <kdudka@redhat.com>
+# Copyright (C) 2010-2025 Kamil Dudka <kdudka@redhat.com>
 #
 # This file is part of predator.
 #
@@ -16,7 +16,7 @@
 # along with predator.  If not, see <http://www.gnu.org/licenses/>.
 
 # project metadata
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(cl C CXX)
 enable_testing()
 

--- a/sl/CMakeLists.txt
+++ b/sl/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (C) 2010-2022 Kamil Dudka <kdudka@redhat.com>
+# Copyright (C) 2010-2025 Kamil Dudka <kdudka@redhat.com>
 #
 # This file is part of predator.
 #
@@ -16,7 +16,7 @@
 # along with predator.  If not, see <http://www.gnu.org/licenses/>.
 
 # project metadata
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5)
 project(sl C CXX)
 enable_testing()
 


### PR DESCRIPTION
... to fix the following CMake 4.0 error:

```
CMake Error at CMakeLists.txt:19 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.

  Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
```